### PR TITLE
Minor bugfix in _set_user_inputs

### DIFF
--- a/coremltools/converters/mil/backend/nn/load.py
+++ b/coremltools/converters/mil/backend/nn/load.py
@@ -84,7 +84,7 @@ def _set_user_inputs(proto, inputs):
         if isinstance(shape, EnumeratedShapes):
             if isinstance(input_type, ImageType):
                 image_sizes = []
-                if input_type.image_config.channel_first:
+                if input_type.channel_first:
                     for s in shape.shapes:
                         image_sizes.append(
                             flexible_shape_utils.NeuralNetworkImageSize(
@@ -99,7 +99,7 @@ def _set_user_inputs(proto, inputs):
                             )
                         )
                 add_enumerated_image_sizes(
-                    proto, input_type.name, image_sizes=image_sizes
+                    proto, input_type.name, sizes=image_sizes
                 )
             else:
                 add_multiarray_ndshape_enumeration(


### PR DESCRIPTION
`channel_first` is a member of `input_type` and for `add_enumerated_image_sizes` the argument name is `sizes`.

If the following input is given to the converter, it currently fails.


> import coremltools as ct
> 
> shapes = [(1, 3, 360, 640), (1, 3, 640, 360)]
> input_shape = ct.EnumeratedShapes(shapes=shapes)
> model_input = ct.ImageType(name='images', shape=input_shape)
> 
> mlmodel = ct.convert(model=traced_model, inputs=[model_input])